### PR TITLE
Using the PubMed Search API with a disease and date range to fetch a …

### DIFF
--- a/api_pubmed.py
+++ b/api_pubmed.py
@@ -1,12 +1,15 @@
 from pprint import pprint
+from time import sleep
+from argparse import ArgumentParser
 import requests
 
-'''
-References Used:
-* https://ualibweb.github.io/UALIB_ScholarlyAPI_Cookbook/src/python/pubmed.html
-* https://www.ncbi.nlm.nih.gov/books/NBK25500/
-'''
 class PubMed:
+    '''
+    References Used:
+    * https://ualibweb.github.io/UALIB_ScholarlyAPI_Cookbook/src/python/pubmed.html
+    * https://www.ncbi.nlm.nih.gov/books/NBK25500/
+    '''
+    
     # Base URL for querying the PubMed API
     base_url = 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils'
 
@@ -19,20 +22,44 @@ class PubMed:
         '''
         return requests.get(f'{self.base_url}/esummary.fcgi?db=pubmed&id={id}&retmode=json').json()
 
+    def query(self, term):
+        return requests.get(f'{self.base_url}/esearch.fcgi?db=pubmed&term={term}&retmode=json').json()
+
 pubmed = PubMed()
 
-def example():
+def get_args():
     '''
-    An example of using PubMed's summary API in order to fetch an article summary,
-    to verify connectivity to the API.
+    Constructs an ArgumentParser with the supported arguments for this script.
     '''
-    pprint(pubmed.get_summary('27933103'))
+    parser = ArgumentParser(
+        prog='api_pubmed',
+        description='Scatter plots number of articles about specific diseases from PubMed over time.')
+    parser.add_argument('--diseases', dest='diseases', default='polio', help='Comma-separated list of disease entries for the search to PubMed (default: polio)')
+    parser.add_argument('--start', dest='start', default='2024', help='Start year (inclusive) (default: 2024)')
+    parser.add_argument('--end', dest='end', default='2025', help='End year (exclusive) (default: 2025)')
+    return parser.parse_args() 
+
+def construct_term(year, month, disease):
+    '''
+    Constructs the search term for the PubMed search API.
+
+    Parameters:
+        year (int) - year of the month's worth of articles we're fetching.
+        month (int) - month number of the month's worth of articles we're fetching.
+        disease (str) - disease that should be mentioned in the article title or abstract.
+    '''
+    return f'%28%28"{year}%2F{month}%2F01"%5BDate+-+Publication%5D+%3A+"{year if month < 12 else year + 1}%2F{month + 1 % 12}%2F01"%5BDate+-+Publication%5D%29%29+AND+%28{disease}%5BTitle%2FAbstract%5D%29'
 
 def main():
     '''
     Entry-point for the script.
     '''
-    example()
+    args = get_args()
+    for year in range(int(args.start), int(args.end)):
+        for month in range(1, 13):
+            for disease in args.diseases.split(','):
+                pprint(pubmed.query(construct_term(year, month, disease)))
+                sleep(1)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
…count of articles

### Description
* using PubMed Search API to get count of articles given year, month, and disease
* taking year range and diseases as command line arguments using ArgumentParser (argparse)

### Testing
```
$ python3 api_pubmed.py

{'esearchresult': {'count': '86',
                   'idlist': ['39170947',
                              '39170726',
                              '39170083',
                              '39146252',
                              '39093896',
                              '38985040',
                              '38959255',
                              '33085381',
                              '38911456',
                              '29262140',
                              '38898820',
                              '38859812',
                              '38846123',
                              '38820454',
                              '38813792',
                              '38784590',
                              '38669524',
                              '38601488',
                              '38593132',
                              '38586072'],
                   'querytranslation': '2024/01/01:2024/02/01[Date - '
                                       'Publication] AND '
                                       '"polio"[Title/Abstract]',
                   'retmax': '20',
                   'retstart': '0',
                   'translationset': []},
 'header': {'type': 'esearch', 'version': '0.3'}}
{'esearchresult': {'count': '50',
                   'idlist': ['38706758',
                              '38678424',
                              '38669157',
                              '38618435',
                              '38618138',
                              '38591277',
                              '38562365',
                              '38549528',
                              '38543880',
                              '38535541',
                              '38535529',
                              '38535527',
                              '38484358',
                              '38456020',
                              '38455598',
                              '38424078',
                              '38422061',
                              '38419000',
                              '38413101',
                              '38400200'],
                   'querytranslation': '2024/02/01:2024/03/01[Date - '
                                       'Publication] AND '
                                       '"polio"[Title/Abstract]',
                   'retmax': '20',
                   'retstart': '0',
                   'translationset': []},
 'header': {'type': 'esearch', 'version': '0.3'}}
{'esearchresult': {'count': '47',
                   'idlist': ['38953798',
                              '38846123',
                              '38711690',
                              '38707147',
                              '38706758',
                              '38681917',
                              '38678424',
                              '38669157',
                              '38668228',
                              '38618435',
                              '38618138',
                              '38617838',
                              '38601488',
                              '38591277',
                              '38562959',
                              '38562365',
                              '38547499',
                              '38543629',
                              '38535567',
                              '38533995'],
                   'querytranslation': '2024/03/01:2024/04/01[Date - '
                                       'Publication] AND '
                                       '"polio"[Title/Abstract]',
                   'retmax': '20',
                   'retstart': '0',
                   'translationset': []},
 'header': {'type': 'esearch', 'version': '0.3'}}
{'esearchresult': {'count': '40',
                   'idlist': ['38953798',
                              '38907687',
                              '38899274',
                              '38792747',
                              '38787229',
                              '38736467',
                              '38711690',
                              '38707147',
                              '38703474',
                              '38681917',
                              '38678424',
                              '38678360',
                              '38675806',
                              '38668278',
                              '38658427',
                              '38655547',
                              '38636960',
                              '38618138',
                              '38599665',
                              '38597896'],
                   'querytranslation': '2024/04/01:2024/05/01[Date - '
                                       'Publication] AND '
                                       '"polio"[Title/Abstract]',
                   'retmax': '20',
                   'retstart': '0',
                   'translationset': []},
 'header': {'type': 'esearch', 'version': '0.3'}}
{'esearchresult': {'count': '34',
                   'idlist': ['38921733',
                              '38910982',
                              '38907687',
                              '38899274',
                              '38821327',
                              '38820454',
                              '38817886',
                              '38815030',
                              '38813942',
                              '38813658',
                              '38809190',
                              '38807038',
                              '38806974',
                              '38797629',
                              '38789689',
                              '38787229',
                              '38784590',
                              '38783823',
                              '38780570',
                              '38770815'],
                   'querytranslation': '2024/05/01:2024/06/01[Date - '
                                       'Publication] AND '
                                       '"polio"[Title/Abstract]',
                   'retmax': '20',
                   'retstart': '0',
                   'translationset': []},
 'header': {'type': 'esearch', 'version': '0.3'}}
{'esearchresult': {'count': '30',
                   'idlist': ['39184633',
                              '39066356',
                              '39049549',
                              '39040054',
                              '39036066',
                              '39035698',
                              '38984086',
                              '38944519',
                              '38935565',
                              '38932666',
                              '20301626',
                              '38915293',
                              '38911456',
                              '38910982',
                              '29262140',
                              '38904997',
                              '38902720',
                              '38889538',
                              '38888347',
                              '38885908'],
                   'querytranslation': '2024/06/01:2024/07/01[Date - '
                                       'Publication] AND '
                                       '"polio"[Title/Abstract]',
                   'retmax': '20',
                   'retstart': '0',
                   'translationset': []},
 'header': {'type': 'esearch', 'version': '0.3'}}
{'esearchresult': {'count': '25',
                   'idlist': ['39184633',
                              '39170726',
                              '39085256',
                              '39081166',
                              '39066397',
                              '39060621',
                              '39060276',
                              '39049549',
                              '39040054',
                              '39037255',
                              '39035698',
                              '39019662',
                              '39010093',
                              '38985040',
                              '38981498',
                              '38969540',
                              '38959255',
                              '33085381',
                              '38889538',
                              '38888347'],
                   'querytranslation': '2024/07/01:2024/08/01[Date - '
                                       'Publication] AND '
                                       '"polio"[Title/Abstract]',
                   'retmax': '20',
                   'retstart': '0',
                   'translationset': []},
 'header': {'type': 'esearch', 'version': '0.3'}}
{'esearchresult': {'count': '25',
                   'idlist': ['39189685',
                              '39181145',
                              '39180777',
                              '39177789',
                              '39172350',
                              '39170947',
                              '39170083',
                              '39163109',
                              '39151947',
                              '39150641',
                              '39146252',
                              '30000133',
                              '39121968',
                              '39098758',
                              '39095876',
                              '39093896',
                              '39081166',
                              '39036066',
                              '39035698',
                              '38949967'],
                   'querytranslation': '2024/08/01:2024/09/01[Date - '
                                       'Publication] AND '
                                       '"polio"[Title/Abstract]',
                   'retmax': '20',
                   'retstart': '0',
                   'translationset': []},
 'header': {'type': 'esearch', 'version': '0.3'}}
{'esearchresult': {'count': '2',
                   'idlist': ['39036066', '38789689'],
                   'querytranslation': '2024/09/01:2024/10/01[Date - '
                                       'Publication] AND '
                                       '"polio"[Title/Abstract]',
                   'retmax': '2',
                   'retstart': '0',
                   'translationset': []},
 'header': {'type': 'esearch', 'version': '0.3'}}
{'esearchresult': {'count': '1',
                   'idlist': ['38821327'],
                   'querytranslation': '2024/10/01:2024/11/01[Date - '
                                       'Publication] AND '
                                       '"polio"[Title/Abstract]',
                   'retmax': '1',
                   'retstart': '0',
                   'translationset': []},
 'header': {'type': 'esearch', 'version': '0.3'}}
{'esearchresult': {'count': '0',
                   'idlist': [],
                   'querytranslation': '2024/11/01:2024/12/01[Date - '
                                       'Publication] AND '
                                       '"polio"[Title/Abstract]',
                   'retmax': '0',
                   'retstart': '0',
                   'translationset': [],
                   'warninglist': {'outputmessages': ['No items found.'],
                                   'phrasesignored': [],
                                   'quotedphrasesnotfound': []}},
 'header': {'type': 'esearch', 'version': '0.3'}}
{'esearchresult': {'count': '0',
                   'idlist': [],
                   'querytranslation': '(("2024/12/01"[Date - Publication] : '
                                       '"2025/13/01"[Date - Publication])) AND '
                                       '(polio[Title/Abstract])',
                   'retmax': '0',
                   'retstart': '0',
                   'translationset': [],
                   'warninglist': {'outputmessages': ['No items found.'],
                                   'phrasesignored': [],
                                   'quotedphrasesnotfound': []}},
 'header': {'type': 'esearch', 'version': '0.3'}}
```